### PR TITLE
Correct g pcr checkbox

### DIFF
--- a/flaskr/model/helpers/peakfunctions.py
+++ b/flaskr/model/helpers/peakfunctions.py
@@ -9,7 +9,10 @@ from flaskr.model.helpers.calcfunctions import fit_poly_equation, get_expected_v
 
 def get_peaks(self, well, derivativenumber, derivative, allpeaks) -> {}:
     timediff = [(self.time[t] + self.time[t + 1]) / 2 for t in range(len(self.time) - 1)]
-    for i in range(2):
+    
+    # For gPCR experiments, we need to skip the first peak on the first dIndex (derivativenumber)
+    num_of_peaks = 1 if derivativenumber == 1 and self.form.get('gPCR') == "True" else 2
+    for i in range(num_of_peaks):
         if derivativenumber == 1:
             if i == 0:
                 #first derivative largest peak

--- a/flaskr/model/processor.py
+++ b/flaskr/model/processor.py
@@ -125,7 +125,7 @@ class Processor(AbstractProcessor):
             #for all samples that match the control sample, collect controls
             if self.control.get_sample() == well.get_sample():
                 self.controllist.append([x for x in well.get_inflections()])
-                if not self.form.get('qcpr'):
+                if not self.form.get('gPCR'):
                     controlCt = self.getCtThreshold(well, derivatives[1], inflectiondict)
                     self.ctlist.append(controlCt)
                     deltact = [0, controlCt['Ct Cycle'], controlCt['Ct RFU']]

--- a/flaskr/templates/inputs.html
+++ b/flaskr/templates/inputs.html
@@ -20,8 +20,8 @@ line-height: 16px;
         <input type="text" name="customlabel"><br>
         <p class="big">
 
-        <label for="gpcr">GPCR experiment</label>
-        <input type="checkbox" id="gpcr" name="gpcr" value="True"></br>
+        <label for="gPCR">gPCR experiment</label>
+        <input type="checkbox" id="gPCR" name="gPCR" value="True"></br>
 
         <div class="groupidentification">
         Group Number


### PR DESCRIPTION
I've tried this fix with a few gPCR files with this and they work normally now. Other experiment types are unaffected. 

It corrects a typo with the gPCR checkox I added before. Then, in get_peaks(), skips the first peak on the first dIndex to prevent crashing. 